### PR TITLE
workflows: don't say Javascript found when there isn't

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,14 +50,17 @@ jobs:
             echo "$DOMAIN not found in data.. Attempting to get page content."
             js_out=$(curl --silent --show-error $DOMAIN | grep -F '<script')
             echo "js snippet found: $js_out"
+            if [ -z $js_out ]; then
+              body="No Javascript found on $DOMAIN"
+            else
+              body="Javascript found on $DOMAIN:
 
-            body="Javascript found on $DOMAIN:
+              \`\`\`$js_out\`\`\`"
 
-            \`\`\`$js_out\`\`\`"
-
-            body="${body//'%'/'%25'}"
-            body="${body//$'\n'/'%0A'}"
-            body="${body//$'\r'/'%0D'}"
+              body="${body//'%'/'%25'}"
+              body="${body//$'\n'/'%0A'}"
+              body="${body//$'\r'/'%0D'}"
+            fi
 
             echo "Comment body: $body"
             echo ::set-output name=comment::$body

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
             echo ::set-output name=comment::"Thank you for your contribution but $DOMAIN already exists in data."
           else
             echo "$DOMAIN not found in data.. Attempting to get page content."
-            js_out=$(curl --silent --show-error $DOMAIN | grep -F '<script')
+            js_out=$(curl --silent --show-error -L $DOMAIN | grep -F '<script')
             echo "js snippet found: $js_out"
             if [ -z $js_out ]; then
               body="No Javascript found on $DOMAIN"


### PR DESCRIPTION
This patch adds a check on whether the output of the curl/grep command is empty. This will avoid confusion in the issues.

You can verify that this is working on the issues section of my fork: https://github.com/humaidq/nojs.club/issues

---

I also added a patch that allows curl to follow redirects, allowing it to find JavaScript on websites with https enabled (curl doesn't follow redirects by default).